### PR TITLE
chore: upgrade bytes to 1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["caching"]
 
 [dependencies]
 async-trait = "~0.1"
-bytes = "~1.9"
+bytes = "~1.10"
 futures = "~0.3"
 log = "~0.4"
 moka = { version = "~0.12", features = ["future"] }


### PR DESCRIPTION
dafafusion upgrades this to `1.10`, so we need to upgrade as well